### PR TITLE
Minor graphical fixes

### DIFF
--- a/src/components/aws/accounts/ListComponent.js
+++ b/src/components/aws/accounts/ListComponent.js
@@ -94,7 +94,7 @@ class ListComponent extends Component {
       ))
     ) : null);
     return (
-      <List disablePadding>
+      <List disablePadding className="accounts-list">
         {noAccounts}
         {accounts}
       </List>

--- a/src/containers/aws/CostBreakdownContainer.js
+++ b/src/containers/aws/CostBreakdownContainer.js
@@ -91,6 +91,7 @@ export class CostBreakdownContainer extends Component {
         rightAlignYAxis={true}
         clipEdge={true}
         showControls={true}
+        stacked={true}
         x={
           /* istanbul ignore next */
           (d) => {

--- a/src/styles/Setup.css
+++ b/src/styles/Setup.css
@@ -4,7 +4,7 @@ ul.MuiList-root-10 li:last-child {
 	border-bottom: none;
 }
 
-.MuiListItemText-root-24 {
+.accounts-list .MuiListItemText-root-24 {
 	font-size: 20px;
 }
 


### PR DESCRIPTION
This reduces the excessive font size of Bills listing due to a CSS rule badly defined.
Also it sets the charts of the cost breakdown to use stacked mode by default.